### PR TITLE
Fix deprecation warning on Ruby 2.4+

### DIFF
--- a/lib/cmess/guess_encoding/automatic.rb
+++ b/lib/cmess/guess_encoding/automatic.rb
@@ -116,6 +116,10 @@ class CMess::GuessEncoding::Automatic
       new(input, chunk_size).guess(ignore_bom)
     end
 
+    def supported_encoding?(encoding)
+      supported_encodings.include?(encoding)
+    end
+
     private
 
     def encoding(*encodings, &block)
@@ -125,10 +129,6 @@ class CMess::GuessEncoding::Automatic
           encoding_guessers   << block
         end
       }
-    end
-
-    def supported_encoding?(encoding)
-      supported_encodings.include?(encoding)
     end
 
     def bom_encoding(encoding, &block)


### PR DESCRIPTION
Fixes #4 