### PR TITLE
Fixes the Warning forwarding to private method by making methods public

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,15 @@
+Metrics/LineLength:
+  Max: 108
+  
+Metrics/MethodLength:
+  Max: 15
+  
+Metrics/AbcSize:
+  Max: 18
+  
+Style/ClassAndModuleChildren:
+  Severity: warning
+  EnforcedStyle: compact
+  
+Style/Documentation:
+  Enabled: false 

--- a/lib/cmess.rb
+++ b/lib/cmess.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #--
 ###############################################################################
 #                                                                             #
@@ -30,26 +32,25 @@
 
 require_relative 'cmess/version'
 
-# See README for more information.
-
+# CMess - Assist with handling messed up encodings. See README for more information.
 module CMess
-
-  DATA_DIR = ENV['CMESS_DATA'] || File.expand_path('../../data', __FILE__)
+  DATA_DIR = ENV['CMESS_DATA'] || File.expand_path('../data', __dir__)
 
   class << self
-
     def ensure_options!(options, *required)
-      values, missing = [], []
+      values = []
+      missing = []
 
-      required.each { |key|
+      required.each do |key|
         value = options[key]
         value.nil? ? missing << key : values << value
-      }
+      end
 
-      missing.empty? ? values : raise(ArgumentError,
-        "required options missing: #{missing.join(', ')}", caller(1))
+      if missing.empty?
+        values
+      else
+        raise(ArgumentError, "required options missing: #{missing.join(', ')}", caller(1))
+      end
     end
-
   end
-
 end

--- a/lib/cmess/bconv.rb
+++ b/lib/cmess/bconv.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #--
 ###############################################################################
 #                                                                             #
@@ -35,7 +37,6 @@ require 'cmess' unless Object.const_defined?(:CMess)
 # Convert between bibliographic (and other) encodings.
 
 class CMess::BConv
-
   VERSION = '0.1.0'
 
   ENCODING = 'utf-8'
@@ -43,7 +44,6 @@ class CMess::BConv
   DEFAULT_CHARTAB_FILE = File.join(CMess::DATA_DIR, 'chartab.yaml')
 
   class << self
-
     def convert(*args)
       new(*args).convert
     end
@@ -51,78 +51,79 @@ class CMess::BConv
     def encodings(chartab = DEFAULT_CHARTAB_FILE)
       chartab = load_chartab(chartab)
 
-      chartab[chartab.keys.first].keys.map { |encoding|
+      chartab[chartab.keys.first].keys.map do |encoding|
         encoding.upcase unless encoding.start_with?('__')
-      }.compact.sort
+      end.compact.sort
     end
 
     def load_chartab(chartab)
       case chartab
-        when Hash
-          chartab
-        when String
-          raise "chartab file not found: #{chartab}" unless File.readable?(chartab)
-          SafeYAML.load_file(chartab)
-        else
-          raise ArgumentError, "invalid chartab of type #{chartab.class}"
+      when Hash
+        chartab
+      when String
+        raise "chartab file not found: #{chartab}" unless File.readable?(chartab)
+
+        SafeYAML.load_file(chartab)
+      else
+        raise ArgumentError, "invalid chartab of type #{chartab.class}"
       end
     end
-
   end
 
   def initialize(options)
-    @input, @output, _ = CMess.ensure_options!(options,
-      :input, :output, :source_encoding, :target_encoding
-    )
+    @input, @output, = CMess.ensure_options!(options,
+                                             :input, :output, :source_encoding, :target_encoding)
 
     @chartab   = self.class.load_chartab(options[:chartab] || DEFAULT_CHARTAB_FILE)
     @encodings = self.class.encodings(@chartab)
 
-    [:source_encoding, :target_encoding].each { |key|
+    %i[source_encoding target_encoding].each do |key|
       instance_variable_set("@#{key}", encoding = options[key].upcase)
       instance_variable_set("@have_#{key}", encodings.include?(encoding))
-    }
+    end
   end
 
   attr_reader :input, :output, :source_encoding, :target_encoding, :chartab, :encodings
 
   def convert
-    source, target, out, charmap = source_encoding, target_encoding, output, {}
+    # TODO: Refactor
+    source = source_encoding
+    target = target_encoding
+    out = output
+    charmap = {}
 
-    if @have_source_encoding
-      if @have_target_encoding
-        chartab.each { |code, map|
-          charmap[map[source]] = map[target].pack('U*')
-        }
+    if @have_source_encoding && @have_target_encoding
+      chartab.each do |_code, map|
+        charmap[map[source]] = map[target].pack('U*')
+      end
 
-        input.each_byte { |char| out.print(map(char, charmap)) }
-      else
-        chartab.each { |code, map|
-          charmap[map[source]] = [code.to_i(16)].pack('U*')
-        }
+      input.each_byte { |char| out.print(map(char, charmap)) }
 
-        source = ENCODING
+    elsif @have_source_encoding
+      chartab.each do |code, map|
+        charmap[map[source]] = [code.to_i(16)].pack('U*')
+      end
 
-        input.each_byte { |char|
-          out.print(encode(map(char, charmap), source, target))
-        }
+      source = ENCODING
+
+      input.each_byte do |char|
+        out.print(encode(map(char, charmap), source, target))
+      end
+
+    elsif @have_target_encoding
+      chartab.each do |code, map|
+        charmap[code.to_i(16)] = map[target].pack('U*')
+      end
+
+      target = ENCODING
+
+      input.each do |line|
+        encode(line, source, target).unpack('U*').each do |char|
+          out.print(charmap[char])
+        end
       end
     else
-      if @have_target_encoding
-        chartab.each { |code, map|
-          charmap[code.to_i(16)] = map[target].pack('U*')
-        }
-
-        target = ENCODING
-
-        input.each { |line|
-          encode(line, source, target).unpack('U*').each { |char|
-            out.print(charmap[char])
-          }
-        }
-      else
-        input.each { |line| out.print(encode(line, source, target)) }
-      end
+      input.each { |line| out.print(encode(line, source, target)) }
     end
   end
 
@@ -135,6 +136,7 @@ class CMess::BConv
   end
 
   def map(char, charmap)
+    # TODO: refactor (too many unlesses here)
     unless map = charmap[[char]]
       unless map = charmap[[char, c = input.getc]]
         input.ungetc(c) if c
@@ -145,4 +147,11 @@ class CMess::BConv
     map
   end
 
+  # def map_refactor(char, charmap)
+  #   # if map = charmap[[char]] fails do
+  #   # if map = charmap[[char, c = input.getc]] fails do
+  #   # reset input (which is what?)
+  #   # set map to ''
+  #   # return map
+  # end
 end

--- a/lib/cmess/bconv.rb
+++ b/lib/cmess/bconv.rb
@@ -146,12 +146,4 @@ class CMess::BConv
 
     map
   end
-
-  # def map_refactor(char, charmap)
-  #   # if map = charmap[[char]] fails do
-  #   # if map = charmap[[char, c = input.getc]] fails do
-  #   # reset input (which is what?)
-  #   # set map to ''
-  #   # return map
-  # end
 end

--- a/lib/cmess/bconv.rb
+++ b/lib/cmess/bconv.rb
@@ -86,7 +86,7 @@ class CMess::BConv
   attr_reader :input, :output, :source_encoding, :target_encoding, :chartab, :encodings
 
   def convert
-    # TODO: Refactor
+    # TODO: Refactor  
     source = source_encoding
     target = target_encoding
     out = output
@@ -146,4 +146,12 @@ class CMess::BConv
 
     map
   end
+
+  # def map_refactor(char, charmap)
+  #   # if map = charmap[[char]] fails do
+  #   # if map = charmap[[char, c = input.getc]] fails do
+  #   # reset input (which is what?)
+  #   # set map to ''
+  #   # return map
+  # end
 end

--- a/lib/cmess/cinderella.rb
+++ b/lib/cmess/cinderella.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #--
 ###############################################################################
 #                                                                             #
@@ -38,7 +40,6 @@ require 'cmess' unless Object.const_defined?(:CMess)
 # encoded characters, substitutes them with their original character.
 
 module CMess::Cinderella
-
   extend self
 
   VERSION = '0.1.1'
@@ -47,24 +48,21 @@ module CMess::Cinderella
 
   def pick(options)
     input, source, target, chars = CMess.ensure_options!(options,
-      :input, :source_encoding, :target_encoding, :chars
-    )
+                                                         :input, :source_encoding, :target_encoding, :chars)
 
-    pot, crop, repair = options.values_at(
-      :pot, :crop, :repair
-    )
+    pot, crop, repair = options.values_at(:pot, :crop, :repair)
 
     encoded = {}
     chars.each { |char| encoded[encode(char, source, target)] = char }
 
     regexp = Regexp.union(*encoded.keys)
 
-    input.each { |line|
-      out = line =~ regexp ? crop : pot or next
+    input.each do |line|
+      (out = line&.match?(regexp) ? crop : pot) || next
 
       line.gsub!(regexp, encoded) if repair
       out.puts(line)
-    }
+    end
   end
 
   private
@@ -73,5 +71,4 @@ module CMess::Cinderella
     string.encode(target, source)
   rescue Encoding::UndefinedConversionError
   end
-
 end

--- a/lib/cmess/decode_entities.rb
+++ b/lib/cmess/decode_entities.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #--
 ###############################################################################
 #                                                                             #
@@ -33,7 +35,6 @@ require 'htmlentities'
 require 'cmess' unless Object.const_defined?(:CMess)
 
 module CMess::DecodeEntities
-
   extend self
 
   VERSION = '0.1.0'
@@ -45,21 +46,22 @@ module CMess::DecodeEntities
 
   def decode(options)
     input, output, source = CMess.ensure_options!(options,
-      :input, :output, :source_encoding
-    )
+                                                  :input, :output, :source_encoding)
 
-    target, entities, encoding = options[:target_encoding] || source,
-      HTMLEntities.new(options[:flavour] || DEFAULT_FLAVOUR), ENCODING
+    target = options[:target_encoding] || source
+    entities = HTMLEntities.new(options[:flavour] || DEFAULT_FLAVOUR)
+    encoding = ENCODING
 
-    skip_source, skip_target = source == encoding, target == encoding
+    skip_source = source == encoding
+    skip_target = target == encoding
 
-    input.each { |line|
+    input.each do |line|
       line = encode(line, source, encoding) unless skip_source
       line = entities.decode(line)
       line = encode(line, encoding, target) unless skip_target
 
       output.puts(line)
-    }
+    end
   end
 
   private
@@ -67,10 +69,9 @@ module CMess::DecodeEntities
   def encode(string, source, target)
     string.encode(target, source)
   end
-
 end
 
-class HTMLEntities  # :nodoc:
+class HTMLEntities # :nodoc:
   FLAVORS << 'xml-safe'
   MAPPINGS['xml-safe'] = MAPPINGS['xhtml1'].dup
   %w[amp apos gt lt quot].each { |key| MAPPINGS['xml-safe'].delete(key) }

--- a/lib/cmess/guess_encoding.rb
+++ b/lib/cmess/guess_encoding.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #--
 ###############################################################################
 #                                                                             #
@@ -39,25 +41,21 @@ require 'cmess' unless Object.const_defined?(:CMess)
 # and Automatic for details.
 
 module CMess::GuessEncoding
-
   VERSION = '0.2.0'
 
   class << self
-
     def manual(*args)
       Manual.display(*args)
     end
 
-    alias_method :display, :manual
+    alias display manual
 
     def automatic(*args)
       Automatic.guess(*args)
     end
 
-    alias_method :guess, :automatic
-
+    alias guess automatic
   end
-
 end
 
 require_relative 'guess_encoding/encoding'

--- a/lib/cmess/guess_encoding/automatic.rb
+++ b/lib/cmess/guess_encoding/automatic.rb
@@ -119,6 +119,10 @@ class CMess::GuessEncoding::Automatic
     def supported_encoding?(encoding)
       supported_encodings.include?(encoding) ## Calls Original Offending Method # Moved to public
     end
+    
+    def supported_bom?(encoding)
+      supported_boms.include?(encoding) # Moved to public
+    end
 
     private
 
@@ -136,10 +140,6 @@ class CMess::GuessEncoding::Automatic
         supported_boms << encoding
         bom_guessers   << lambda { |*| encoding if instance_eval(&block) }
       end
-    end
-
-    def supported_bom?(encoding)
-      supported_boms.include?(encoding)
     end
 
   end

--- a/lib/cmess/guess_encoding/automatic.rb
+++ b/lib/cmess/guess_encoding/automatic.rb
@@ -50,7 +50,7 @@ class CMess::GuessEncoding::Automatic
 
   extend Forwardable
 
-  def_delegators self, :encoding_guessers, :supported_encoding?,  #Here is the issue supported_encoding is private but delegated
+  def_delegators self, :encoding_guessers, :supported_encoding?,
                        :bom_guessers,      :supported_bom?
 
   include CMess::GuessEncoding::Encoding
@@ -117,11 +117,11 @@ class CMess::GuessEncoding::Automatic
     end
     
     def supported_encoding?(encoding)
-      supported_encodings.include?(encoding) ## Calls Original Offending Method # Moved to public
+      supported_encodings.include?(encoding)
     end
     
     def supported_bom?(encoding)
-      supported_boms.include?(encoding) # Moved to public
+      supported_boms.include?(encoding) 
     end
 
     private
@@ -162,7 +162,7 @@ class CMess::GuessEncoding::Automatic
 
     while read
       encoding_guessers.each { |block|
-        if encoding = instance_eval(&block) and supported_encoding?(encoding) # Offending line. 
+        if encoding = instance_eval(&block) and supported_encoding?(encoding) 
           return encoding
         end
       }
@@ -192,7 +192,7 @@ class CMess::GuessEncoding::Automatic
     end
 
     bom_guessers.each { |block|
-      if encoding = instance_eval(&block) and supported_encoding?(encoding) # Should also be Offending line
+      if encoding = instance_eval(&block) and supported_encoding?(encoding)
         return encoding
       else
         input.rewind

--- a/lib/cmess/guess_encoding/automatic.rb
+++ b/lib/cmess/guess_encoding/automatic.rb
@@ -162,8 +162,7 @@ class CMess::GuessEncoding::Automatic
 
     while read
       encoding_guessers.each { |block|
-        if encoding = instance_eval(&block) 
-            and supported_encoding?(encoding) # Offending line. 
+        if encoding = instance_eval(&block) and supported_encoding?(encoding) # Offending line. 
           return encoding
         end
       }
@@ -193,8 +192,7 @@ class CMess::GuessEncoding::Automatic
     end
 
     bom_guessers.each { |block|
-      if encoding = instance_eval(&block) 
-          and supported_encoding?(encoding) # Should also be Offending line
+      if encoding = instance_eval(&block) and supported_encoding?(encoding) # Should also be Offending line
         return encoding
       else
         input.rewind

--- a/lib/cmess/guess_encoding/automatic.rb
+++ b/lib/cmess/guess_encoding/automatic.rb
@@ -217,7 +217,7 @@ class CMess::GuessEncoding::Automatic
     bytes.include?(next_byte)
   end
 
-  def read(chunk_size = chunk_size)
+  def read(chunk_size = @chunk_size)
     @byte_count ||= Hash.new(0)
     @byte_total ||= 0
 

--- a/lib/cmess/guess_encoding/automatic.rb
+++ b/lib/cmess/guess_encoding/automatic.rb
@@ -35,7 +35,7 @@
 #++
 
 require 'stringio'
-require 'forwardable'
+require 'forwardable'  # This is part of the Offending issue
 require 'safe_yaml/load'
 
 # Tries to detect the encoding of a given input by applying several
@@ -50,7 +50,7 @@ class CMess::GuessEncoding::Automatic
 
   extend Forwardable
 
-  def_delegators self, :encoding_guessers, :supported_encoding?,
+  def_delegators self, :encoding_guessers, :supported_encoding?,  #Here is the issue supported_encoding is private but delegated
                        :bom_guessers,      :supported_bom?
 
   include CMess::GuessEncoding::Encoding
@@ -115,6 +115,10 @@ class CMess::GuessEncoding::Automatic
     def guess(input, chunk_size = nil, ignore_bom = false)
       new(input, chunk_size).guess(ignore_bom)
     end
+    
+    def supported_encoding?(encoding)
+      supported_encodings.include?(encoding) ## Calls Original Offending Method # Moved to public
+    end
 
     private
 
@@ -125,10 +129,6 @@ class CMess::GuessEncoding::Automatic
           encoding_guessers   << block
         end
       }
-    end
-
-    def supported_encoding?(encoding)
-      supported_encodings.include?(encoding)
     end
 
     def bom_encoding(encoding, &block)
@@ -162,7 +162,8 @@ class CMess::GuessEncoding::Automatic
 
     while read
       encoding_guessers.each { |block|
-        if encoding = instance_eval(&block) and supported_encoding?(encoding)
+        if encoding = instance_eval(&block) 
+            and supported_encoding?(encoding) # Offending line. 
           return encoding
         end
       }
@@ -192,7 +193,8 @@ class CMess::GuessEncoding::Automatic
     end
 
     bom_guessers.each { |block|
-      if encoding = instance_eval(&block) and supported_encoding?(encoding)
+      if encoding = instance_eval(&block) 
+          and supported_encoding?(encoding) # Should also be Offending line
         return encoding
       else
         input.rewind

--- a/lib/cmess/guess_encoding/automatic.rb
+++ b/lib/cmess/guess_encoding/automatic.rb
@@ -1,4 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
+
+# rubocop:disable Naming/MethodName
 
 #--
 ###############################################################################
@@ -35,7 +37,7 @@
 #++
 
 require 'stringio'
-require 'forwardable'  # This is part of the Offending issue
+require 'forwardable'
 require 'safe_yaml/load'
 
 # Tries to detect the encoding of a given input by applying several
@@ -47,11 +49,10 @@ require 'safe_yaml/load'
 # For supported encodings see EncodingGuessers and BOMGuessers.
 
 class CMess::GuessEncoding::Automatic
-
   extend Forwardable
 
   def_delegators self, :encoding_guessers, :supported_encoding?,
-                       :bom_guessers,      :supported_bom?
+                 :bom_guessers, :supported_bom?
 
   include CMess::GuessEncoding::Encoding
 
@@ -76,20 +77,21 @@ class CMess::GuessEncoding::Automatic
     CP1252,
     CP850,
     MS_ANSI
-  ]
+  ].freeze
 
   # Certain (non-ASCII) chars to test for in TEST_ENCODINGS.
-  CHARS_TO_TEST = (
-    '€‚ƒ„…†‡ˆ‰Š‹ŒŽ‘’“”•–—˜™š›œžŸ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂ' <<
+  CHARS_TO_TEST =
+    '€‚ƒ„…†‡ˆ‰Š‹ŒŽ‘’“”•–—˜™š›œžŸ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂ' \
     'ÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ'
-  ).chars.to_a
+    .chars.to_a
 
   # Map TEST_ENCODINGS to respectively encoded CHARS_TO_TEST.
-  TEST_CHARS = Hash.new { |h, k|
-    e, f = self[k], UTF_8
+  TEST_CHARS = Hash.new do |h, k|
+    e = self[k]
+    f = UTF_8
     TEST_ENCODINGS << e unless TEST_ENCODINGS.include?(e)
     h[e] = CHARS_TO_TEST.flat_map { |c| c.encode(e, f).unpack('C') }
-  }.update(SafeYAML.load_file(File.join(CMess::DATA_DIR, 'test_chars.yaml')))
+  end.update(SafeYAML.load_file(File.join(CMess::DATA_DIR, 'test_chars.yaml')))
 
   # Relative count of TEST_CHARS must exceed this threshold to yield
   # a direct match.
@@ -100,7 +102,7 @@ class CMess::GuessEncoding::Automatic
   TEST_THRESHOLD_APPROX = 0.0004
 
   # Pattern for method names in EncodingGuessers and BOMGuessers.
-  GUESS_METHOD_RE = %r{\A((?:bom_)?encoding)_\d+_(.+)\z}
+  GUESS_METHOD_RE = /\A((?:bom_)?encoding)_\d+_(.+)\z/.freeze
 
   @supported_encodings = []
   @encoding_guessers   = []
@@ -108,49 +110,50 @@ class CMess::GuessEncoding::Automatic
   @bom_guessers        = []
 
   class << self
-
     attr_reader :supported_encodings, :encoding_guessers,
                 :supported_boms,      :bom_guessers
 
     def guess(input, chunk_size = nil, ignore_bom = false)
       new(input, chunk_size).guess(ignore_bom)
     end
-    
+
     def supported_encoding?(encoding)
       supported_encodings.include?(encoding)
     end
-    
+
     def supported_bom?(encoding)
-      supported_boms.include?(encoding) 
+      supported_boms.include?(encoding)
     end
 
     private
 
     def encoding(*encodings, &block)
-      encodings.flatten.each { |encoding|
+      encodings.flatten.each do |encoding|
         unless supported_encoding?(encoding)
           supported_encodings << encoding
           encoding_guessers   << block
         end
-      }
+      end
     end
 
     def bom_encoding(encoding, &block)
       unless supported_bom?(encoding)
         supported_boms << encoding
-        bom_guessers   << lambda { |*| encoding if instance_eval(&block) }
+        bom_guessers   << ->(*) { encoding if instance_eval(&block) }
       end
     end
-
   end
 
   def initialize(input, chunk_size = nil)
-    @input = case input
-      when IO     then input
-      when String then StringIO.new(input)
-      else raise ArgumentError,
-        "don't know how to handle input of type #{input.class}"
-    end
+    @input =
+      case input
+      when IO     then
+        input
+      when String then
+        StringIO.new(input)
+      else
+        raise ArgumentError, "don't know how to handle input of type #{input.class}"
+      end
 
     @chunk_size = chunk_size
   end
@@ -161,11 +164,11 @@ class CMess::GuessEncoding::Automatic
     return bom if bom && !ignore_bom
 
     while read
-      encoding_guessers.each { |block|
-        if encoding = instance_eval(&block) and supported_encoding?(encoding) 
+      encoding_guessers.each do |block|
+        if (encoding = instance_eval(&block)) && supported_encoding?(encoding)
           return encoding
         end
-      }
+      end
     end
 
     UNKNOWN
@@ -191,19 +194,19 @@ class CMess::GuessEncoding::Automatic
       return
     end
 
-    bom_guessers.each { |block|
-      if encoding = instance_eval(&block) and supported_encoding?(encoding)
+    bom_guessers.each do |block|
+      if (encoding = instance_eval(&block)) && supported_encoding?(encoding)
         return encoding
       else
         input.rewind
       end
-    }
+    end
 
     nil
   end
 
   def next_byte
-    input.read(1).unpack('C').first
+    input.read(1).unpack1('C')
   end
 
   def starts_with?(*bytes)
@@ -214,7 +217,7 @@ class CMess::GuessEncoding::Automatic
     bytes.include?(next_byte)
   end
 
-  def read(chunk_size = chunk_size())
+  def read(chunk_size = chunk_size)
     @byte_count ||= Hash.new(0)
     @byte_total ||= 0
 
@@ -222,12 +225,12 @@ class CMess::GuessEncoding::Automatic
 
     bytes_before = @byte_total
 
-    input.read(chunk_size).each_byte { |byte|
+    input.read(chunk_size).each_byte do |byte|
       @byte_count[byte] += 1
       @byte_total       += 1
 
       @first_byte ||= byte
-    }
+    end
 
     @byte_total > bytes_before
   end
@@ -243,7 +246,6 @@ class CMess::GuessEncoding::Automatic
   # Definition of guessing heuristics. Order matters!
 
   module EncodingGuessers
-
     include CMess::GuessEncoding::Encoding
 
     # ASCII[http://en.wikipedia.org/wiki/ASCII], if all bytes are
@@ -259,10 +261,10 @@ class CMess::GuessEncoding::Automatic
     def encoding_02_UTF_32_and_UTF_16BE_and_UTF_16LE_and_UTF_16
       if relative_byte_count(byte_count[0]) > 0.25
         case first_byte
-          when 0x00 then UTF_32
-          when 0xfe then UTF_16BE
-          when 0xff then UTF_16LE
-          else           UTF_16
+        when 0x00 then UTF_32
+        when 0xfe then UTF_16BE
+        when 0xff then UTF_16LE
+        else UTF_16
         end
       end
     end
@@ -275,9 +277,9 @@ class CMess::GuessEncoding::Automatic
                   byte_count_sum(0xe0..0xef) * 2 +
                   # => 1110xxxx 10xxxxxx 10xxxxxx
                   byte_count_sum(0xf0..0xf7) * 3
-                  # => 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+      # => 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
 
-      UTF_8 if esc_bytes > 0 && esc_bytes == byte_count_sum(0x80..0xbf)
+      UTF_8 if esc_bytes.positive? && esc_bytes == byte_count_sum(0x80..0xbf)
     end
 
     # TEST_ENCODINGS, if frequency of TEST_CHARS exceeds TEST_THRESHOLD_DIRECT
@@ -286,20 +288,18 @@ class CMess::GuessEncoding::Automatic
       ratios = {}
 
       TEST_ENCODINGS.find(lambda {
-        ratio, encoding = ratios.sort.last
+        ratio, encoding = ratios.max
         encoding if ratio >= TEST_THRESHOLD_APPROX
-      }) { |encoding|
+      }) do |encoding|
         ratio = relative_byte_count(byte_count_sum(TEST_CHARS[encoding]))
         ratio >= TEST_THRESHOLD_DIRECT || (ratios[ratio] ||= encoding; false)
-      }
+      end
     end
-
   end
 
   # BOM[http://en.wikipedia.org/wiki/Byte_order_mark] detection.
 
   module BOMGuessers
-
     # UTF-8[http://en.wikipedia.org/wiki/UTF-8]
     def bom_encoding_01_UTF_8
       starts_with?(0xef, 0xbb, 0xbf)
@@ -354,18 +354,19 @@ class CMess::GuessEncoding::Automatic
     def bom_encoding_11_GB_18030
       starts_with?(0x84, 0x31, 0x95, 0x33)
     end
-
   end
 
-  [EncodingGuessers, BOMGuessers].each { |mod|
+  [EncodingGuessers, BOMGuessers].each do |mod|
     include mod
 
-    mod.instance_methods(false).sort.each { |method|
+    mod.instance_methods(false).sort.each do |method|
       next unless method =~ GUESS_METHOD_RE
-      name, list = $1, $2.split('_and_')
+
+      name = Regexp.last_match(1)
+      list = Regexp.last_match(2).split('_and_')
 
       send(name, *list.map { |encoding| const_get(encoding) }) { send(method) }
-    }
-  }
-
+    end
+  end
 end
+# rubocop:enable Naming/MethodName

--- a/lib/cmess/guess_encoding/encoding.rb
+++ b/lib/cmess/guess_encoding/encoding.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 #--
 ###############################################################################
 #                                                                             #
@@ -37,11 +35,12 @@
 # Namespace for our encodings.
 
 module CMess::GuessEncoding::Encoding
+
   extend self
 
   def all_encodings
-    if const_defined?(:ALL_ENCODINGS)
-      ALL_ENCODINGS
+    if const_defined?(:ALL_ENCODINGS) then 
+      ALL_ENCODINGS 
     else
       const_set(:ALL_ENCODINGS, get_all_encodings)
     end
@@ -51,8 +50,8 @@ module CMess::GuessEncoding::Encoding
     get_or_set_encoding_const(encoding)
   end
 
-  private(:get_all_encodings, :const_name_for, :set_encoding_const, :get_or_set_encoding_const)
   private_class_method :included
+  private
 
   def get_all_encodings
     Encoding.name_list.map { |encoding| get_or_set_encoding_const(encoding) }
@@ -67,9 +66,9 @@ module CMess::GuessEncoding::Encoding
   end
 
   def get_or_set_encoding_const(encoding)
-    if const_defined?(const = const_name_for(encoding))
-      const_get(const)
-    else
+    if const_defined?(const = const_name_for(encoding)) then 
+      const_get(const) 
+    else 
       set_encoding_const(encoding, const)
     end
   end
@@ -88,4 +87,5 @@ module CMess::GuessEncoding::Encoding
   def self.included(base)
     base.extend(self)
   end
+
 end

--- a/lib/cmess/guess_encoding/encoding.rb
+++ b/lib/cmess/guess_encoding/encoding.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #--
 ###############################################################################
 #                                                                             #
@@ -35,19 +37,22 @@
 # Namespace for our encodings.
 
 module CMess::GuessEncoding::Encoding
-
   extend self
 
   def all_encodings
-    const_defined?(:ALL_ENCODINGS) ? ALL_ENCODINGS :
+    if const_defined?(:ALL_ENCODINGS)
+      ALL_ENCODINGS
+    else
       const_set(:ALL_ENCODINGS, get_all_encodings)
+    end
   end
 
   def [](encoding)
     get_or_set_encoding_const(encoding)
   end
 
-  private
+  private(:get_all_encodings, :const_name_for, :set_encoding_const, :get_or_set_encoding_const)
+  private_class_method :included
 
   def get_all_encodings
     Encoding.name_list.map { |encoding| get_or_set_encoding_const(encoding) }
@@ -62,8 +67,11 @@ module CMess::GuessEncoding::Encoding
   end
 
   def get_or_set_encoding_const(encoding)
-    const_defined?(const = const_name_for(encoding)) ?
-      const_get(const) : set_encoding_const(encoding, const)
+    if const_defined?(const = const_name_for(encoding))
+      const_get(const)
+    else
+      set_encoding_const(encoding, const)
+    end
   end
 
   %w[
@@ -80,5 +88,4 @@ module CMess::GuessEncoding::Encoding
   def self.included(base)
     base.extend(self)
   end
-
 end

--- a/lib/cmess/guess_encoding/encoding.rb
+++ b/lib/cmess/guess_encoding/encoding.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+# rubocop:disable Naming/AccessorMethodName
+
 #--
 ###############################################################################
 #                                                                             #
@@ -35,12 +39,11 @@
 # Namespace for our encodings.
 
 module CMess::GuessEncoding::Encoding
-
   extend self
 
   def all_encodings
-    if const_defined?(:ALL_ENCODINGS) then 
-      ALL_ENCODINGS 
+    if const_defined?(:ALL_ENCODINGS)
+      ALL_ENCODINGS
     else
       const_set(:ALL_ENCODINGS, get_all_encodings)
     end
@@ -51,6 +54,7 @@ module CMess::GuessEncoding::Encoding
   end
 
   private_class_method :included
+
   private
 
   def get_all_encodings
@@ -66,9 +70,9 @@ module CMess::GuessEncoding::Encoding
   end
 
   def get_or_set_encoding_const(encoding)
-    if const_defined?(const = const_name_for(encoding)) then 
-      const_get(const) 
-    else 
+    if const_defined?(const = const_name_for(encoding))
+      const_get(const)
+    else
       set_encoding_const(encoding, const)
     end
   end
@@ -87,5 +91,5 @@ module CMess::GuessEncoding::Encoding
   def self.included(base)
     base.extend(self)
   end
-
 end
+# rubocop:enable Naming/AccessorMethodName

--- a/lib/cmess/guess_encoding/manual.rb
+++ b/lib/cmess/guess_encoding/manual.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #--
 ###############################################################################
 #                                                                             #
@@ -42,8 +44,7 @@ require 'nuggets/enumerable/minmax'
 # with its desired appearance.
 
 module CMess::GuessEncoding::Manual
-
-  extend self
+  module_function
 
   include CMess::GuessEncoding::Encoding
 
@@ -58,7 +59,7 @@ module CMess::GuessEncoding::Manual
     CP850,
     CP852,
     UTF_8
-  ]
+  ].freeze
 
   # Likely candidates to suggest to the user
   CANDIDATES = [
@@ -78,7 +79,7 @@ module CMess::GuessEncoding::Manual
     UTF_32,
     UTF_32BE,
     UTF_32LE
-  ]
+  ].freeze
 
   def display(options)
     input, target = CMess.ensure_options!(options, :input, :target_encoding)
@@ -95,22 +96,22 @@ module CMess::GuessEncoding::Manual
     # move target encoding to front
     encodings.in_order!(target)
 
-    max_length, reverse = encodings.max(:length), options[:reverse]
+    max_length = encodings.max(:length)
+    reverse = options[:reverse]
 
-    encodings.each { |encoding|
+    encodings.each do |encoding|
       args = [target, encoding]
       args.reverse! if reverse
 
       converted = begin
         input.encode(*args)
-      rescue Encoding::UndefinedConversionError => err
-        "ILLEGAL INPUT SEQUENCE: #{err.error_char}"
-      rescue Encoding::ConverterNotFoundError => err
-        err.to_s
+                  rescue Encoding::UndefinedConversionError => err
+                    "ILLEGAL INPUT SEQUENCE: #{err.error_char}"
+                  rescue Encoding::ConverterNotFoundError => err
+                    err.to_s
       end
 
-      puts "%-#{max_length}s : %s" % [encoding, converted]
-    }
+      puts format("%-#{max_length}s : %s", encoding, converted)
+    end
   end
-
 end

--- a/lib/cmess/version.rb
+++ b/lib/cmess/version.rb
@@ -1,13 +1,12 @@
+# frozen_string_literal: true
+
 module CMess
-
   module Version
-
     MAJOR = 0
     MINOR = 5
-    TINY  = 1
+    TINY  = 2
 
     class << self
-
       # Returns array representation.
       def to_a
         [MAJOR, MINOR, TINY]
@@ -17,11 +16,8 @@ module CMess
       def to_s
         to_a.join('.')
       end
-
     end
-
   end
 
   VERSION = Version.to_s
-
 end


### PR DESCRIPTION
I could find no reason to keep the methods private, so made the public. 

Changes:
- Made public :supported_encoding? and :supported_bom?
- Bumped up the minor version
- Added rubocop.yml
- Ran rubocop linter with autocorrect 
- Fixed certain rubocop errors
- Added TODOs for large rubocop errors (for a future pull request from me) 

Please squash merge (commits are messy) if accepted. 
